### PR TITLE
fix renamed repository cloning

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -53,9 +53,9 @@ and even activate its route(s). The world's now yours to `require('🌍')`
 1.  Clone this repository:
 
     ```bash
-    git clone git@github.com:detroitenglish/cloudflare-worker-webpack-boilerplate.git
+    git clone git@github.com:detroitenglish/cloudflare-workers-webpack-boilerplate.git
 
-    cd cloudflare-worker-webpack-boilerplate
+    cd cloudflare-workers-webpack-boilerplate
     ```
 
 2.  Rename `example.env` to `.env` , and add your required Cloudflare


### PR DESCRIPTION
Currently it clones a repository with just a README telling to clone the renamed repository. This pull request will fix this.